### PR TITLE
AJ add node status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,14 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Changed
 - removed cruft from /lib
+
+## [0.1.0] - 2015-07-06
+
+### Added
+- `check-es-node-status` node status check
+
+### Fixed
+- uri resource path for `get_es_resource` method
+
+### Changed
+- `get_es_resource` URI path needs to start with `/`

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 
 ## Files
  * /bin/check-es-cluster-status.rb
- * /bin/check-es-heap.rb
- * /bin/metrics-es-node-graphite.rb
  * /bin/check-es-file-descriptors.rb
+ * /bin/check-es-heap.rb
+ * /bin/check-es-node-status.rb
  * /bin/metrics-es-cluster.rb
  * /bin/metrics-es-node.rb
+ * /bin/metrics-es-node-graphite.rb
 
 ## Usage
 

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -62,7 +62,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          default: 30
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     critical 'Connection refused'
@@ -79,7 +79,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
 
   def master?
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
-      master = get_es_resource('_cluster/state/master_node')['master_node']
+      master = get_es_resource('/_cluster/state/master_node')['master_node']
       local = get_es_resource('/_nodes/_local')
     else
       master = get_es_resource('/_cluster/state?filter_routing_table=true&filter_metadata=true&filter_indices=true')['master_node']

--- a/bin/check-es-file-descriptors.rb
+++ b/bin/check-es-file-descriptors.rb
@@ -67,7 +67,7 @@ class ESFileDescriptors < Sensu::Plugin::Check::CLI
          default: 80
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'

--- a/bin/check-es-heap.rb
+++ b/bin/check-es-heap.rb
@@ -80,7 +80,7 @@ class ESHeap < Sensu::Plugin::Check::CLI
   end
 
   def acquire_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
@@ -92,10 +92,10 @@ class ESHeap < Sensu::Plugin::Check::CLI
 
   def acquire_heap_data(return_max = false) # rubocop:disable all
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
-      stats = acquire_es_resource('_nodes/_local/stats?jvm=true')
+      stats = acquire_es_resource('/_nodes/_local/stats?jvm=true')
       node = stats['nodes'].keys.first
     else
-      stats = acquire_es_resource('_cluster/nodes/_local/stats?jvm=true')
+      stats = acquire_es_resource('/_cluster/nodes/_local/stats?jvm=true')
       node = stats['nodes'].keys.first
     end
     begin

--- a/bin/check-es-node-status.rb
+++ b/bin/check-es-node-status.rb
@@ -51,7 +51,7 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
          long: '--timeout SECS',
          proc: proc(&:to_i),
          default: 30
-  
+
   def get_es_resource(resource)
     r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
@@ -63,7 +63,7 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
     critical 'Connection reset by peer'
   end
 
-  def get_status
+  def acquire_status
     health = get_es_resource('/')
     health['status'].to_i
   end
@@ -76,7 +76,5 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
     else
       critical "Dead (#{node_status})"
     end
-
   end
-
 end

--- a/bin/check-es-node-status.rb
+++ b/bin/check-es-node-status.rb
@@ -1,0 +1,82 @@
+#! /usr/bin/env ruby
+#
+#  check-es-node-status
+#
+# DESCRIPTION:
+#   This plugin checks the ElasticSearch node status, using its API.
+#   Works with ES 0.9x and ES 1.x
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   check-es-node-status --help
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2012 Sonian, Inc <chefs@sonian.net>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+require 'json'
+
+class ESNodeStatus < Sensu::Plugin::Check::CLI
+  option :host,
+         description: 'Elasticsearch host',
+         short: '-h HOST',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :port,
+         description: 'Elasticsearch port',
+         short: '-p PORT',
+         long: '--port PORT',
+         proc: proc(&:to_i),
+         default: 9200
+
+  option :timeout,
+         description: 'Sets the connection timeout for REST client',
+         short: '-t SECS',
+         long: '--timeout SECS',
+         proc: proc(&:to_i),
+         default: 30
+  
+  def get_es_resource(resource)
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
+    JSON.parse(r.get)
+  rescue Errno::ECONNREFUSED
+    critical 'Connection refused'
+  rescue RestClient::RequestTimeout
+    critical 'Connection timed out'
+  rescue Errno::ECONNRESET
+    critical 'Connection reset by peer'
+  end
+
+  def get_status
+    health = get_es_resource('/')
+    health['status'].to_i
+  end
+
+  def run
+    node_status = get_status
+
+    if node_status == 200
+      ok "Alive #{(node_status)}"
+    else
+      critical "Dead (#{node_status})"
+    end
+
+  end
+
+end

--- a/bin/check-es-node-status.rb
+++ b/bin/check-es-node-status.rb
@@ -69,7 +69,7 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
   end
 
   def run
-    node_status = get_status
+    node_status = acquire_status
 
     if node_status == 200
       ok "Alive #{(node_status)}"

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -68,7 +68,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'

--- a/bin/metrics-es-node-graphite.rb
+++ b/bin/metrics-es-node-graphite.rb
@@ -94,7 +94,7 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: false
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/#{resource}?pretty", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}#{resource}?pretty", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
@@ -139,9 +139,9 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
     end
 
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
-      stats = get_es_resource("_nodes/_local/stats?#{stats_query_string}")
+      stats = get_es_resource("/_nodes/_local/stats?#{stats_query_string}")
     else
-      stats = get_es_resource("_cluster/nodes/_local/stats?#{stats_query_string}")
+      stats = get_es_resource("/_cluster/nodes/_local/stats?#{stats_query_string}")
     end
 
     timestamp = Time.now.to_i

--- a/lib/sensu-plugins-elasticsearch/version.rb
+++ b/lib/sensu-plugins-elasticsearch/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsElasticsearch
   module Version
     MAJOR = 0
-    MINOR = 0
-    PATCH = 2
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
This PR addresses the following:

* Add a node status check so there is an option for the node itself to be checked.
* The uri resource path was being resolved as `http://localhost:9200//_cluster/state/master_node` (notice the `//`) in most places, fixed it. Also standardized the uri resource path so when calling `get_es_resource` the route starts with `/`.
* Bumped gem version according to `semver.org` guidelines.

> How should I deal with revisions in the 0.y.z initial development phase?
>
> The simplest thing to do is start your initial development release at 0.1.0 and then increment the minor  version for each subsequent release.
>
> http://semver.org/