### PR TITLE
Leveraging the elasticsearch gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
  * /bin/check-es-file-descriptors.rb
  * /bin/check-es-heap.rb
  * /bin/check-es-node-status.rb
+ * /bin/check-es-query-count.rb
+ * /bin/check-es-query-exists.rb
  * /bin/metrics-es-cluster.rb
  * /bin/metrics-es-node.rb
  * /bin/metrics-es-node-graphite.rb

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -30,7 +30,7 @@ require 'sensu-plugin/check/cli'
 require 'elasticsearch'
 require 'time'
 
-require 'sensu-plugins-elasticsearch'
+require_relative '../lib/sensu-plugins-elasticsearch/elasticsearch-common.rb'
 
 #
 # ES Heap
@@ -55,7 +55,7 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
 
   option :hours_previous,
          description: 'Hours before now to check @timestamp against query.',
-         long: '--hours-previous DAYS_PREVIOUS',
+         long: '--hours-previous HOURS_PREVIOUS',
          proc: proc(&:to_i),
          default: 0
 

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -39,10 +39,10 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
   include ElasticsearchCommon
 
   option :index,
-         description: """Elasticsearch indices to query.
+         description: 'Elasticsearch indices to query.
          Comma-separated list of index names to search.
          Use `_all` or empty string to perform the operation on all indices.
-         Accepts wildcards""",
+         Accepts wildcards',
          short: '-i INDEX',
          long: '--indices INDEX'
 

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -16,7 +16,12 @@
 #   gem: elasticsearch
 #
 # USAGE:
-#   example commands
+#   This example checks that the count of special_type logs matching a query of
+#       anything (*) at the host elasticsearch.service.consul for the past 90 minutes
+#       will warn if there are under 100 and go critical if the result count is below 1
+#       (The invert flag warns if counts are _below_ the critical and warning values)
+#   check-es-query-count.rb -h elasticsearch.service.consul -q "*" --invert
+#           --types special_type -d 'logging-%Y.%m.%d' --minutes-previous 90 -p 9200 -c 1 -w 100
 #
 # NOTES:
 #

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -1,0 +1,193 @@
+#! /usr/bin/env ruby
+#
+#   check-es-query
+#
+# DESCRIPTION:
+#   This plugin checks an ElasticSearch query.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: elasticsearch
+#
+# USAGE:
+#   example commands
+#
+# NOTES:
+#
+# LICENSE:
+#   Brendan Gibat <brendan.gibat@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'elasticsearch'
+require 'time'
+
+require 'sensu-plugins-elasticsearch'
+
+#
+# ES Heap
+#
+class ESQueryCount < Sensu::Plugin::Check::CLI
+  include ElasticsearchCommon
+
+  option :index,
+         description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
+         short: '-i INDEX',
+         long: '--indices INDEX'
+
+  option :types,
+         description: 'Elasticsearch types to limit searches to, comma separated list.',
+         long: '--types TYPES'
+
+  option :minutes_previous,
+         description: 'Minutes before now to check @timestamp against query.',
+         long: '--minutes-previous MINUTES_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :hours_previous,
+         description: 'Hours before now to check @timestamp against query.',
+         long: '--hours-previous DAYS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :days_previous,
+         description: 'Days before now to check @timestamp against query.',
+         long: '--days-previous DAYS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :weeks_previous,
+         description: 'Weeks before now to check @timestamp against query.',
+         long: '--weeks-previous WEEKS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :months_previous,
+         description: 'Months before now to check @timestamp against query.',
+         long: '--months-previous MONTHS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :date_index,
+         description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
+         short: '-d DATE_INDEX',
+         long: '--date-index DATE_INDEX'
+
+  option :date_repeat_daily,
+         description: 'Elasticsearch date based index repeats daily.',
+         long: '--repeat-daily',
+         boolean: true,
+         default: true
+
+  option :date_repeat_hourly,
+         description: 'Elasticsearch date based index repeats hourly.',
+         long: '--repeat-hourly',
+         boolean: true,
+         default: false
+
+  option :query,
+         description: 'Elasticsearch query',
+         short: '-q QUERY',
+         long: '--query QUERY',
+         required: true
+
+  option :host,
+         description: 'Elasticsearch host',
+         short: '-h HOST',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :port,
+         description: 'Elasticsearch port',
+         short: '-p PORT',
+         long: '--port PORT',
+         proc: proc(&:to_i),
+         default: 9200
+
+  option :scheme,
+         description: 'Elasticsearch connection scheme, defaults to https for authenticated connections',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: 'https'
+
+  option :password,
+         description: 'Elasticsearch connection password',
+         short: '-P PASSWORD',
+         long: '--password PASSWORD'
+
+  option :user,
+         description: 'Elasticsearch connection user',
+         short: '-u USER',
+         long: '--user USER'
+
+  option :timeout,
+         description: 'Elasticsearch query timeout in seconds',
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 30
+
+  option :warn,
+         short: '-w N',
+         long: '--warn N',
+         description: 'Result count WARNING threshold',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :crit,
+         short: '-c N',
+         long: '--crit N',
+         description: 'Result count CRITICAL threshold',
+         proc: proc(&:to_i),
+         default: 0
+
+  option :invert,
+         long: '--invert',
+         description: 'Invert thresholds',
+         boolean: true
+
+  def run # rubocop:disable all
+
+    begin
+        response = client.count(build_request_options)
+        if config[:invert]
+            if response["count"] < config[:crit]
+                critical "Query count was below critical threshold"
+            elsif response["count"] < config[:warn]
+                warning "Query count was below warning threshold"
+            else
+                ok
+            end
+        else
+            if response["count"] > config[:crit]
+                critical "Query count was above critical threshold"
+            elsif response["count"] > config[:warn]
+                warning "Query count was above warning threshold"
+            else
+                ok
+            end
+        end
+    rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        if config[:invert]
+            if response["count"] < config[:crit]
+                critical "Query count was below critical threshold"
+            elsif response["count"] < config[:warn]
+                warning "Query count was below warning threshold"
+            else
+                ok
+            end
+        else
+            ok "No results found, count was below thresholds"
+        end
+    end
+  end
+end

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -81,8 +81,8 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
          default: 0
 
   option :date_index,
-         description: """Elasticsearch time based index.
-            Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime""",
+         description: 'Elasticsearch time based index.
+            Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
          short: '-d DATE_INDEX',
          long: '--date-index DATE_INDEX'
 

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -156,38 +156,35 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
          boolean: true
 
   def run # rubocop:disable all
-
-    begin
-        response = client.count(build_request_options)
-        if config[:invert]
-            if response["count"] < config[:crit]
-                critical "Query count was below critical threshold"
-            elsif response["count"] < config[:warn]
-                warning "Query count was below warning threshold"
-            else
-                ok
-            end
-        else
-            if response["count"] > config[:crit]
-                critical "Query count was above critical threshold"
-            elsif response["count"] > config[:warn]
-                warning "Query count was above warning threshold"
-            else
-                ok
-            end
-        end
-    rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
-        if config[:invert]
-            if response["count"] < config[:crit]
-                critical "Query count was below critical threshold"
-            elsif response["count"] < config[:warn]
-                warning "Query count was below warning threshold"
-            else
-                ok
-            end
-        else
-            ok "No results found, count was below thresholds"
-        end
+    response = client.count(build_request_options)
+    if config[:invert]
+      if response['count'] < config[:crit]
+        critical 'Query count was below critical threshold'
+      elsif response['count'] < config[:warn]
+        warning 'Query count was below warning threshold'
+      else
+        ok
+      end
+    else
+      if response['count'] > config[:crit]
+        critical 'Query count was above critical threshold'
+      elsif response['count'] > config[:warn]
+        warning 'Query count was above warning threshold'
+      else
+        ok
+      end
     end
+rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+  if config[:invert]
+    if response['count'] < config[:crit]
+      critical 'Query count was below critical threshold'
+    elsif response['count'] < config[:warn]
+      warning 'Query count was below warning threshold'
+    else
+      ok
+    end
+  else
+    ok 'No results found, count was below thresholds'
+  end
   end
 end

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -39,7 +39,10 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
   include ElasticsearchCommon
 
   option :index,
-         description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
+         description: """Elasticsearch indices to query.
+         Comma-separated list of index names to search.
+         Use `_all` or empty string to perform the operation on all indices.
+         Accepts wildcards""",
          short: '-i INDEX',
          long: '--indices INDEX'
 
@@ -78,7 +81,8 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
          default: 0
 
   option :date_index,
-         description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
+         description: """Elasticsearch time based index.
+            Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime""",
          short: '-d DATE_INDEX',
          long: '--date-index DATE_INDEX'
 

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -174,7 +174,7 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
         ok
       end
     end
-rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+rescue Elasticsearch::Transport::Transport::Errors::NotFound
   if config[:invert]
     if response['count'] < config[:crit]
       critical 'Query count was below critical threshold'

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -30,7 +30,7 @@ require 'sensu-plugin/check/cli'
 require 'elasticsearch'
 require 'time'
 
-require_relative '../lib/sensu-plugins-elasticsearch/elasticsearch-common.rb'
+require 'sensu-plugins-elasticsearch'
 
 #
 # ES Heap

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -30,7 +30,7 @@ require 'sensu-plugin/check/cli'
 require 'elasticsearch'
 require 'time'
 
-require 'sensu-plugins-elasticsearch'
+require_relative 'sensu-plugins-elasticsearch'
 
 #
 # ES Heap

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -1,0 +1,165 @@
+#! /usr/bin/env ruby
+#
+#   check-es-query-exists
+#
+# DESCRIPTION:
+#   This plugin checks an ElasticSearch query that documents exist.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: elasticsearch
+#
+# USAGE:
+#   example commands
+#
+# NOTES:
+#
+# LICENSE:
+#   Brendan Gibat <brendan.gibat@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'elasticsearch'
+require 'sensu-plugins-elasticsearch'
+
+#
+# ES Heap
+#
+class ESQueryExists < Sensu::Plugin::Check::CLI
+  include ElasticsearchCommon
+
+
+    option :index,
+           description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
+           short: '-i INDEX',
+           long: '--indices INDEX'
+
+    option :types,
+           description: 'Elasticsearch types to limit searches to, comma separated list.',
+           long: '--types TYPES'
+
+    option :minutes_previous,
+           description: 'Minutes before now to check @timestamp against query.',
+           long: '--minutes-previous MINUTES_PREVIOUS',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :hours_previous,
+           description: 'Hours before now to check @timestamp against query.',
+           long: '--hours-previous DAYS_PREVIOUS',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :days_previous,
+           description: 'Days before now to check @timestamp against query.',
+           long: '--days-previous DAYS_PREVIOUS',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :weeks_previous,
+           description: 'Weeks before now to check @timestamp against query.',
+           long: '--weeks-previous WEEKS_PREVIOUS',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :months_previous,
+           description: 'Months before now to check @timestamp against query.',
+           long: '--months-previous MONTHS_PREVIOUS',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :date_index,
+           description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
+           short: '-d DATE_INDEX',
+           long: '--date-index DATE_INDEX'
+
+    option :date_repeat_daily,
+           description: 'Elasticsearch date based index repeats daily.',
+           long: '--repeat-daily',
+           boolean: true,
+           default: true
+
+    option :date_repeat_hourly,
+           description: 'Elasticsearch date based index repeats hourly.',
+           long: '--repeat-hourly',
+           boolean: true,
+           default: false
+
+    option :query,
+           description: 'Elasticsearch query',
+           short: '-q QUERY',
+           long: '--query QUERY',
+           required: true
+
+    option :host,
+           description: 'Elasticsearch host',
+           short: '-h HOST',
+           long: '--host HOST',
+           default: 'localhost'
+
+    option :port,
+           description: 'Elasticsearch port',
+           short: '-p PORT',
+           long: '--port PORT',
+           proc: proc(&:to_i),
+           default: 9200
+
+    option :scheme,
+           description: 'Elasticsearch connection scheme, defaults to https for authenticated connections',
+           short: '-s SCHEME',
+           long: '--scheme SCHEME',
+           default: 'https'
+
+    option :password,
+           description: 'Elasticsearch connection password',
+           short: '-P PASSWORD',
+           long: '--password PASSWORD'
+
+    option :user,
+           description: 'Elasticsearch connection user',
+           short: '-u USER',
+           long: '--user USER'
+
+    option :timeout,
+           description: 'Elasticsearch query timeout in seconds',
+           short: '-t TIMEOUT',
+           long: '--timeout TIMEOUT',
+           proc: proc(&:to_i),
+           default: 30
+
+    option :warn,
+           short: '-w N',
+           long: '--warn N',
+           description: 'Result count WARNING threshold',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :crit,
+           short: '-c N',
+           long: '--crit N',
+           description: 'Result count CRITICAL threshold',
+           proc: proc(&:to_i),
+           default: 0
+
+    option :invert,
+           long: '--invert',
+           description: 'Invert thresholds',
+           boolean: true
+
+    def run # rubocop:disable all
+      begin
+          client.exists(build_request_options)
+          ok
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+          critical
+      end
+    end
+end

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -16,7 +16,14 @@
 #   gem: elasticsearch
 #
 # USAGE:
-#   example commands
+#   This example checks that the count of special_type logs matching a query of
+#       "docker.args:special AND *specialstring* AND _exists_:key.name"
+#       at the host elasticsearch.service.consul and port 9200 for the past 3 minutes
+#       will go critical if there are NO results for that period. 
+#       This check is to ensure that events are happening at all.
+#   check-es-query-exists.rb -h elasticsearch.service.consul
+#           -q "docker.args:special AND *specialstring* AND _exists_:key.name" --invert
+#           --types special_type -d 'logging-%Y.%m.%d' --minutes-previous 3 -p 9200
 #
 # NOTES:
 #

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -37,7 +37,10 @@ class ESQueryExists < Sensu::Plugin::Check::CLI
   include ElasticsearchCommon
 
   option :index,
-         description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
+         description: 'Elasticsearch indices to query.
+         Comma-separated list of index names to search.
+         Use `_all` or empty string to perform the operation on all indices.
+         Accepts wildcards',
          short: '-i INDEX',
          long: '--indices INDEX'
 
@@ -76,7 +79,8 @@ class ESQueryExists < Sensu::Plugin::Check::CLI
          default: 0
 
   option :date_index,
-         description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
+         description: 'Elasticsearch time based index.
+         Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
          short: '-d DATE_INDEX',
          long: '--date-index DATE_INDEX'
 

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -19,7 +19,7 @@
 #   This example checks that the count of special_type logs matching a query of
 #       "docker.args:special AND *specialstring* AND _exists_:key.name"
 #       at the host elasticsearch.service.consul and port 9200 for the past 3 minutes
-#       will go critical if there are NO results for that period. 
+#       will go critical if there are NO results for that period.
 #       This check is to ensure that events are happening at all.
 #   check-es-query-exists.rb -h elasticsearch.service.consul
 #           -q "docker.args:special AND *specialstring* AND _exists_:key.name" --invert

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -156,7 +156,7 @@ class ESQueryExists < Sensu::Plugin::Check::CLI
     def run # rubocop:disable all
       client.exists(build_request_options)
       ok
-  rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
     critical
     end
 end

--- a/bin/check-es-query-exists.rb
+++ b/bin/check-es-query-exists.rb
@@ -36,130 +36,127 @@ require 'sensu-plugins-elasticsearch'
 class ESQueryExists < Sensu::Plugin::Check::CLI
   include ElasticsearchCommon
 
+  option :index,
+         description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
+         short: '-i INDEX',
+         long: '--indices INDEX'
 
-    option :index,
-           description: 'Elasticsearch indices to query. comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices. Accepts wildcards',
-           short: '-i INDEX',
-           long: '--indices INDEX'
+  option :types,
+         description: 'Elasticsearch types to limit searches to, comma separated list.',
+         long: '--types TYPES'
 
-    option :types,
-           description: 'Elasticsearch types to limit searches to, comma separated list.',
-           long: '--types TYPES'
+  option :minutes_previous,
+         description: 'Minutes before now to check @timestamp against query.',
+         long: '--minutes-previous MINUTES_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :minutes_previous,
-           description: 'Minutes before now to check @timestamp against query.',
-           long: '--minutes-previous MINUTES_PREVIOUS',
-           proc: proc(&:to_i),
-           default: 0
+  option :hours_previous,
+         description: 'Hours before now to check @timestamp against query.',
+         long: '--hours-previous DAYS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :hours_previous,
-           description: 'Hours before now to check @timestamp against query.',
-           long: '--hours-previous DAYS_PREVIOUS',
-           proc: proc(&:to_i),
-           default: 0
+  option :days_previous,
+         description: 'Days before now to check @timestamp against query.',
+         long: '--days-previous DAYS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :days_previous,
-           description: 'Days before now to check @timestamp against query.',
-           long: '--days-previous DAYS_PREVIOUS',
-           proc: proc(&:to_i),
-           default: 0
+  option :weeks_previous,
+         description: 'Weeks before now to check @timestamp against query.',
+         long: '--weeks-previous WEEKS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :weeks_previous,
-           description: 'Weeks before now to check @timestamp against query.',
-           long: '--weeks-previous WEEKS_PREVIOUS',
-           proc: proc(&:to_i),
-           default: 0
+  option :months_previous,
+         description: 'Months before now to check @timestamp against query.',
+         long: '--months-previous MONTHS_PREVIOUS',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :months_previous,
-           description: 'Months before now to check @timestamp against query.',
-           long: '--months-previous MONTHS_PREVIOUS',
-           proc: proc(&:to_i),
-           default: 0
+  option :date_index,
+         description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
+         short: '-d DATE_INDEX',
+         long: '--date-index DATE_INDEX'
 
-    option :date_index,
-           description: 'Elasticsearch time based index. Accepts format from http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime',
-           short: '-d DATE_INDEX',
-           long: '--date-index DATE_INDEX'
+  option :date_repeat_daily,
+         description: 'Elasticsearch date based index repeats daily.',
+         long: '--repeat-daily',
+         boolean: true,
+         default: true
 
-    option :date_repeat_daily,
-           description: 'Elasticsearch date based index repeats daily.',
-           long: '--repeat-daily',
-           boolean: true,
-           default: true
+  option :date_repeat_hourly,
+         description: 'Elasticsearch date based index repeats hourly.',
+         long: '--repeat-hourly',
+         boolean: true,
+         default: false
 
-    option :date_repeat_hourly,
-           description: 'Elasticsearch date based index repeats hourly.',
-           long: '--repeat-hourly',
-           boolean: true,
-           default: false
+  option :query,
+         description: 'Elasticsearch query',
+         short: '-q QUERY',
+         long: '--query QUERY',
+         required: true
 
-    option :query,
-           description: 'Elasticsearch query',
-           short: '-q QUERY',
-           long: '--query QUERY',
-           required: true
+  option :host,
+         description: 'Elasticsearch host',
+         short: '-h HOST',
+         long: '--host HOST',
+         default: 'localhost'
 
-    option :host,
-           description: 'Elasticsearch host',
-           short: '-h HOST',
-           long: '--host HOST',
-           default: 'localhost'
+  option :port,
+         description: 'Elasticsearch port',
+         short: '-p PORT',
+         long: '--port PORT',
+         proc: proc(&:to_i),
+         default: 9200
 
-    option :port,
-           description: 'Elasticsearch port',
-           short: '-p PORT',
-           long: '--port PORT',
-           proc: proc(&:to_i),
-           default: 9200
+  option :scheme,
+         description: 'Elasticsearch connection scheme, defaults to https for authenticated connections',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: 'https'
 
-    option :scheme,
-           description: 'Elasticsearch connection scheme, defaults to https for authenticated connections',
-           short: '-s SCHEME',
-           long: '--scheme SCHEME',
-           default: 'https'
+  option :password,
+         description: 'Elasticsearch connection password',
+         short: '-P PASSWORD',
+         long: '--password PASSWORD'
 
-    option :password,
-           description: 'Elasticsearch connection password',
-           short: '-P PASSWORD',
-           long: '--password PASSWORD'
+  option :user,
+         description: 'Elasticsearch connection user',
+         short: '-u USER',
+         long: '--user USER'
 
-    option :user,
-           description: 'Elasticsearch connection user',
-           short: '-u USER',
-           long: '--user USER'
+  option :timeout,
+         description: 'Elasticsearch query timeout in seconds',
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 30
 
-    option :timeout,
-           description: 'Elasticsearch query timeout in seconds',
-           short: '-t TIMEOUT',
-           long: '--timeout TIMEOUT',
-           proc: proc(&:to_i),
-           default: 30
+  option :warn,
+         short: '-w N',
+         long: '--warn N',
+         description: 'Result count WARNING threshold',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :warn,
-           short: '-w N',
-           long: '--warn N',
-           description: 'Result count WARNING threshold',
-           proc: proc(&:to_i),
-           default: 0
+  option :crit,
+         short: '-c N',
+         long: '--crit N',
+         description: 'Result count CRITICAL threshold',
+         proc: proc(&:to_i),
+         default: 0
 
-    option :crit,
-           short: '-c N',
-           long: '--crit N',
-           description: 'Result count CRITICAL threshold',
-           proc: proc(&:to_i),
-           default: 0
-
-    option :invert,
-           long: '--invert',
-           description: 'Invert thresholds',
-           boolean: true
+  option :invert,
+         long: '--invert',
+         description: 'Invert thresholds',
+         boolean: true
 
     def run # rubocop:disable all
-      begin
-          client.exists(build_request_options)
-          ok
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
-          critical
-      end
+      client.exists(build_request_options)
+      ok
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+    critical
     end
 end

--- a/lib/sensu-plugins-elasticsearch.rb
+++ b/lib/sensu-plugins-elasticsearch.rb
@@ -1,1 +1,2 @@
 require 'sensu-plugins-elasticsearch/version'
+require 'sensu-plugins-elasticsearch/elasticsearch-common'

--- a/lib/sensu-plugins-elasticsearch.rb
+++ b/lib/sensu-plugins-elasticsearch.rb
@@ -1,2 +1,3 @@
 require 'sensu-plugins-elasticsearch/version'
 require 'sensu-plugins-elasticsearch/elasticsearch-common'
+require 'sensu-plugins-elasticsearch/elasticsearch-query'

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -15,8 +15,7 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
-
-require 'sensu-plugins-elasticsearch'
+require_relative "elasticsearch-query.rb"
 
 module ElasticsearchCommon
   include ElasticsearchQuery

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -15,7 +15,7 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
-require_relative "elasticsearch-query.rb"
+require_relative 'elasticsearch-query.rb'
 
 module ElasticsearchCommon
   include ElasticsearchQuery

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -16,7 +16,10 @@
 #   for details.
 #
 
+require 'sensu-plugins-elasticsearch'
+
 module ElasticsearchCommon
+  include ElasticsearchQuery
   def initialize
     super()
   end
@@ -35,108 +38,6 @@ module ElasticsearchCommon
       else
         Elasticsearch::Client.new host: "#{config[:host]}:#{config[:port]}", request_timeout: config[:timeout]
       end
-    end
-  end
-
-  def indices
-    if !config[:index].nil?
-      return config[:index]
-    elsif !config[:date_index].nil?
-      indices = []
-      curr = Time.now.utc.to_i
-      start = curr
-
-      if config[:minutes_previous] != 0
-        start -= (config[:minutes_previous] * 60)
-      end
-      if config[:hours_previous] != 0
-        start -= (config[:hours_previous] * 60 * 60)
-      end
-      if config[:days_previous] != 0
-        start -= (config[:days_previous] * 60 * 60 * 24)
-      end
-      if config[:weeks_previous] != 0
-        start -= (config[:weeks_previous] * 60 * 60 * 24 * 7)
-      end
-      if config[:months_previous] != 0
-        start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
-      end
-      total = 60 * 60 * 24
-      if config[:date_repeat_hourly]
-        total = 60 * 60
-      end
-      (start.to_i..curr.to_i).step(total) do |step|
-        indices.push(Time.at(step).utc.strftime config[:date_index])
-      end
-      unless indices.include?(Time.at(curr).utc.strftime config[:date_index])
-        indices.push(Time.at(curr).utc.strftime config[:date_index])
-      end
-      return indices.join(',')
-    end
-    ['_all']
-  end
-
-  def build_request_options
-    options = {
-      index: indices,
-      ignore_unavailable: true
-    }
-    if !config[:body].nil?
-      options[:body] = config[:body]
-    else
-      es_date_filter = es_date_math_string
-      unless es_date_filter.nil?
-        options[:body] = {
-          'query' => {
-            'filtered' => {
-              'query' => {
-                'query_string' => {
-                  'default_field' => 'message',
-                  'query' => config[:query]
-                }
-              },
-              'filter' => {
-                'range' => {
-                  '@timestamp' => {
-                    'gt' => es_date_filter
-                  }
-                }
-              }
-            }
-          }
-        }
-      end
-    end
-    unless config[:types].nil?
-      options[:type] = config[:types]
-    end
-    options
-  end
-
-  def es_date_math_string
-    if config[:minutes_previous] == 0 && \
-       config[:hours_previous] == 0 && \
-       config[:weeks_previous] == 0 && \
-       config[:months_previous] == 0
-      return nil
-    else
-      es_math = "#{Time.now.utc.strftime '%Y-%m-%dT%H:%M:%S'}||"
-      if config[:minutes_previous] != 0
-        es_math += "-#{config[:minutes_previous]}m"
-      end
-      if config[:hours_previous] != 0
-        es_math += "-#{config[:hours_previous]}h"
-      end
-      if config[:days_previous] != 0
-        es_math += "-#{config[:days_previous]}d"
-      end
-      if config[:weeks_previous] != 0
-        es_math += "-#{config[:weeks_previous]}w"
-      end
-      if config[:months_previous] != 0
-        es_math += "-#{config[:months_previous]}M"
-      end
-      return es_math
     end
   end
 end

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -38,7 +38,7 @@ module ElasticsearchCommon
     end
   end
 
-  def get_indices
+  def indices
     if !config[:index].nil?
       return config[:index]
     elsif !config[:date_index].nil?
@@ -78,13 +78,13 @@ module ElasticsearchCommon
 
   def build_request_options
     options = {
-      index: get_indices,
+      index: indices,
       ignore_unavailable: true
     }
     if !config[:body].nil?
       options[:body] = config[:body]
     else
-      es_date_filter = get_es_date_math_string
+      es_date_filter = es_date_math_string
       unless es_date_filter.nil?
         options[:body] = {
           'query' => {
@@ -113,7 +113,7 @@ module ElasticsearchCommon
     options
   end
 
-  def get_es_date_math_string
+  def es_date_math_string
     if config[:minutes_previous] == 0 && \
        config[:hours_previous] == 0 && \
        config[:weeks_previous] == 0 && \

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -61,11 +61,11 @@ module ElasticsearchCommon
       if config[:months_previous] != 0
         start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
       end
-      step = 60 * 60 * 24
+      total = 60 * 60 * 24
       if config[:date_repeat_hourly]
-        step = 60 * 60
+        total = 60 * 60
       end
-      (start.to_i..curr.to_i).step(step) do |step|
+      (start.to_i..curr.to_i).step(total) do |step|
         indices.push(Time.at(step).utc.strftime config[:date_index])
       end
       unless indices.include?(Time.at(curr).utc.strftime config[:date_index])

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -1,0 +1,144 @@
+#
+# DESCRIPTION:
+#   Common helper methods
+#
+# DEPENDENCIES:
+#   gem: elasticsearch
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Brendan Gibat <brendan.gibat@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+module ElasticsearchCommon
+
+    def initialize
+        super()
+    end
+
+    def client
+        @client ||= begin
+            if config[:user] != nil && config[:pass] != nil && config[:scheme] != nil
+                Elasticsearch::Client.new hosts: [{
+                    host:               config[:host],
+                    port:               config[:port],
+                    user:               config[:user],
+                    password:           config[:password],
+                    scheme:             config[:scheme],
+                    request_timeout:    config[:timeout]
+                    }]
+            else
+                Elasticsearch::Client.new host:"#{config[:host]}:#{config[:port]}", request_timeout:config[:timeout]
+            end
+        end
+    end
+
+    def get_indices
+      if config[:index] != nil
+          return config[:index]
+      elsif config[:date_index] != nil
+          indices = []
+          curr = Time.now.utc.to_i
+          start = curr
+
+          if config[:minutes_previous] != 0
+              start -= (config[:minutes_previous] * 60)
+          end
+          if config[:hours_previous] != 0
+              start -= (config[:hours_previous] * 60 * 60)
+          end
+          if config[:days_previous] != 0
+              start -= (config[:days_previous] * 60 * 60 * 24)
+          end
+          if config[:weeks_previous] != 0
+              start -= (config[:weeks_previous] * 60 * 60 * 24 * 7)
+          end
+          if config[:months_previous] != 0
+              start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
+          end
+          step = 60 * 60 * 24
+          if config[:date_repeat_hourly]
+              step = 60 * 60
+          end
+          (start.to_i..curr.to_i).step(step) do |step|
+              indices.push(Time.at(step).utc.strftime config[:date_index])
+          end
+          if !indices.include?(Time.at(curr).utc.strftime config[:date_index])
+              indices += (Time.at(step).utc.strftime config[:date_index])
+          end
+          return indices.join(",")
+      end
+      return "_all"
+    end
+
+    def build_request_options
+        options = {
+            :index => get_indices,
+            :ignore_unavailable => true
+            }
+        if config[:body] != nil
+            options[:body] = config[:body]
+        else
+            es_date_filter = get_es_date_math_string
+            if es_date_filter != nil
+                options[:body] = {
+                    "query" => {
+                        "filtered" => {
+                            "query" => {
+                                "query_string" => {
+                                    "default_field" => "message",
+                                    "query" => config[:query]
+                                }
+                            },
+                            "filter"=> {
+                                "range" => {
+                                    "@timestamp" => {
+                                        "gt" => es_date_filter
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            end
+        end
+        if config[:types] != nil
+            options[:types] = config[:types]
+        end
+        return options
+    end
+
+    def get_es_date_math_string
+      if config[:minutes_previous] == 0 && \
+          config[:hours_previous] == 0 && \
+          config[:weeks_previous] == 0 && \
+          config[:months_previous] == 0
+          return nil
+      else
+          es_math = "#{Time.now.utc.strftime "%Y-%m-%dT%H:%M:%S"}||"
+          if config[:minutes_previous] != 0
+              es_math += "-#{config[:minutes_previous]}m"
+          end
+          if config[:hours_previous] != 0
+              es_math += "-#{config[:hours_previous]}h"
+          end
+          if config[:days_previous] != 0
+              es_math += "-#{config[:days_previous]}d"
+          end
+          if config[:weeks_previous] != 0
+              es_math += "-#{config[:weeks_previous]}w"
+          end
+          if config[:months_previous] != 0
+              es_math += "-#{config[:months_previous]}M"
+          end
+          return es_math
+      end
+    end
+
+end

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -109,7 +109,7 @@ module ElasticsearchCommon
             end
         end
         if config[:types] != nil
-            options[:types] = config[:types]
+            options[:type] = config[:types]
         end
         return options
     end

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -17,128 +17,126 @@
 #
 
 module ElasticsearchCommon
+  def initialize
+    super()
+  end
 
-    def initialize
-        super()
-    end
-
-    def client
-        @client ||= begin
-            if config[:user] != nil && config[:pass] != nil && config[:scheme] != nil
-                Elasticsearch::Client.new hosts: [{
-                    host:               config[:host],
-                    port:               config[:port],
-                    user:               config[:user],
-                    password:           config[:password],
-                    scheme:             config[:scheme],
-                    request_timeout:    config[:timeout]
-                    }]
-            else
-                Elasticsearch::Client.new host:"#{config[:host]}:#{config[:port]}", request_timeout:config[:timeout]
-            end
-        end
-    end
-
-    def get_indices
-      if config[:index] != nil
-          return config[:index]
-      elsif config[:date_index] != nil
-          indices = []
-          curr = Time.now.utc.to_i
-          start = curr
-
-          if config[:minutes_previous] != 0
-              start -= (config[:minutes_previous] * 60)
-          end
-          if config[:hours_previous] != 0
-              start -= (config[:hours_previous] * 60 * 60)
-          end
-          if config[:days_previous] != 0
-              start -= (config[:days_previous] * 60 * 60 * 24)
-          end
-          if config[:weeks_previous] != 0
-              start -= (config[:weeks_previous] * 60 * 60 * 24 * 7)
-          end
-          if config[:months_previous] != 0
-              start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
-          end
-          step = 60 * 60 * 24
-          if config[:date_repeat_hourly]
-              step = 60 * 60
-          end
-          (start.to_i..curr.to_i).step(step) do |step|
-              indices.push(Time.at(step).utc.strftime config[:date_index])
-          end
-          if !indices.include?(Time.at(curr).utc.strftime config[:date_index])
-              indices.push(Time.at(curr).utc.strftime config[:date_index])
-          end
-          return indices.join(",")
-      end
-      return ["_all"]
-    end
-
-    def build_request_options
-        options = {
-            :index => get_indices,
-            :ignore_unavailable => true
-            }
-        if config[:body] != nil
-            options[:body] = config[:body]
-        else
-            es_date_filter = get_es_date_math_string
-            if es_date_filter != nil
-                options[:body] = {
-                    "query" => {
-                        "filtered" => {
-                            "query" => {
-                                "query_string" => {
-                                    "default_field" => "message",
-                                    "query" => config[:query]
-                                }
-                            },
-                            "filter"=> {
-                                "range" => {
-                                    "@timestamp" => {
-                                        "gt" => es_date_filter
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            end
-        end
-        if config[:types] != nil
-            options[:type] = config[:types]
-        end
-        return options
-    end
-
-    def get_es_date_math_string
-      if config[:minutes_previous] == 0 && \
-          config[:hours_previous] == 0 && \
-          config[:weeks_previous] == 0 && \
-          config[:months_previous] == 0
-          return nil
+  def client
+    @client ||= begin
+      if !config[:user].nil? && !config[:pass].nil? && !config[:scheme].nil?
+        Elasticsearch::Client.new hosts: [{
+          host:               config[:host],
+          port:               config[:port],
+          user:               config[:user],
+          password:           config[:password],
+          scheme:             config[:scheme],
+          request_timeout:    config[:timeout]
+        }]
       else
-          es_math = "#{Time.now.utc.strftime "%Y-%m-%dT%H:%M:%S"}||"
-          if config[:minutes_previous] != 0
-              es_math += "-#{config[:minutes_previous]}m"
-          end
-          if config[:hours_previous] != 0
-              es_math += "-#{config[:hours_previous]}h"
-          end
-          if config[:days_previous] != 0
-              es_math += "-#{config[:days_previous]}d"
-          end
-          if config[:weeks_previous] != 0
-              es_math += "-#{config[:weeks_previous]}w"
-          end
-          if config[:months_previous] != 0
-              es_math += "-#{config[:months_previous]}M"
-          end
-          return es_math
+        Elasticsearch::Client.new host: "#{config[:host]}:#{config[:port]}", request_timeout: config[:timeout]
       end
     end
+  end
 
+  def get_indices
+    if !config[:index].nil?
+      return config[:index]
+    elsif !config[:date_index].nil?
+      indices = []
+      curr = Time.now.utc.to_i
+      start = curr
+
+      if config[:minutes_previous] != 0
+        start -= (config[:minutes_previous] * 60)
+      end
+      if config[:hours_previous] != 0
+        start -= (config[:hours_previous] * 60 * 60)
+      end
+      if config[:days_previous] != 0
+        start -= (config[:days_previous] * 60 * 60 * 24)
+      end
+      if config[:weeks_previous] != 0
+        start -= (config[:weeks_previous] * 60 * 60 * 24 * 7)
+      end
+      if config[:months_previous] != 0
+        start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
+      end
+      step = 60 * 60 * 24
+      if config[:date_repeat_hourly]
+        step = 60 * 60
+      end
+      (start.to_i..curr.to_i).step(step) do |step|
+        indices.push(Time.at(step).utc.strftime config[:date_index])
+      end
+      unless indices.include?(Time.at(curr).utc.strftime config[:date_index])
+        indices.push(Time.at(curr).utc.strftime config[:date_index])
+      end
+      return indices.join(',')
+    end
+    ['_all']
+  end
+
+  def build_request_options
+    options = {
+      index: get_indices,
+      ignore_unavailable: true
+    }
+    if !config[:body].nil?
+      options[:body] = config[:body]
+    else
+      es_date_filter = get_es_date_math_string
+      unless es_date_filter.nil?
+        options[:body] = {
+          'query' => {
+            'filtered' => {
+              'query' => {
+                'query_string' => {
+                  'default_field' => 'message',
+                  'query' => config[:query]
+                }
+              },
+              'filter' => {
+                'range' => {
+                  '@timestamp' => {
+                    'gt' => es_date_filter
+                  }
+                }
+              }
+            }
+          }
+        }
+      end
+    end
+    unless config[:types].nil?
+      options[:type] = config[:types]
+    end
+    options
+  end
+
+  def get_es_date_math_string
+    if config[:minutes_previous] == 0 && \
+       config[:hours_previous] == 0 && \
+       config[:weeks_previous] == 0 && \
+       config[:months_previous] == 0
+      return nil
+    else
+      es_math = "#{Time.now.utc.strftime '%Y-%m-%dT%H:%M:%S'}||"
+      if config[:minutes_previous] != 0
+        es_math += "-#{config[:minutes_previous]}m"
+      end
+      if config[:hours_previous] != 0
+        es_math += "-#{config[:hours_previous]}h"
+      end
+      if config[:days_previous] != 0
+        es_math += "-#{config[:days_previous]}d"
+      end
+      if config[:weeks_previous] != 0
+        es_math += "-#{config[:weeks_previous]}w"
+      end
+      if config[:months_previous] != 0
+        es_math += "-#{config[:months_previous]}M"
+      end
+      return es_math
+    end
+  end
 end

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-common.rb
@@ -70,11 +70,11 @@ module ElasticsearchCommon
               indices.push(Time.at(step).utc.strftime config[:date_index])
           end
           if !indices.include?(Time.at(curr).utc.strftime config[:date_index])
-              indices += (Time.at(step).utc.strftime config[:date_index])
+              indices.push(Time.at(curr).utc.strftime config[:date_index])
           end
           return indices.join(",")
       end
-      return "_all"
+      return ["_all"]
     end
 
     def build_request_options

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
@@ -1,0 +1,125 @@
+#
+# DESCRIPTION:
+#   Common search helper methods
+#
+# DEPENDENCIES:
+#   gem: elasticsearch
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Brendan Gibat <brendan.gibat@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+module ElasticsearchQuery
+  def initialize
+    super()
+  end
+
+  def indices
+    if !config[:index].nil?
+      return config[:index]
+    elsif !config[:date_index].nil?
+      indices = []
+      curr = Time.now.utc.to_i
+      start = curr
+
+      if config[:minutes_previous] != 0
+        start -= (config[:minutes_previous] * 60)
+      end
+      if config[:hours_previous] != 0
+        start -= (config[:hours_previous] * 60 * 60)
+      end
+      if config[:days_previous] != 0
+        start -= (config[:days_previous] * 60 * 60 * 24)
+      end
+      if config[:weeks_previous] != 0
+        start -= (config[:weeks_previous] * 60 * 60 * 24 * 7)
+      end
+      if config[:months_previous] != 0
+        start -= (config[:months_previous] * 60 * 60 * 24 * 7 * 31)
+      end
+      total = 60 * 60 * 24
+      if config[:date_repeat_hourly]
+        total = 60 * 60
+      end
+      (start.to_i..curr.to_i).step(total) do |step|
+        indices.push(Time.at(step).utc.strftime config[:date_index])
+      end
+      unless indices.include?(Time.at(curr).utc.strftime config[:date_index])
+        indices.push(Time.at(curr).utc.strftime config[:date_index])
+      end
+      return indices.join(',')
+    end
+    ['_all']
+  end
+
+  def build_request_options
+    options = {
+      index: indices,
+      ignore_unavailable: true
+    }
+    if !config[:body].nil?
+      options[:body] = config[:body]
+    else
+      es_date_filter = es_date_math_string
+      unless es_date_filter.nil?
+        options[:body] = {
+          'query' => {
+            'filtered' => {
+              'query' => {
+                'query_string' => {
+                  'default_field' => 'message',
+                  'query' => config[:query]
+                }
+              },
+              'filter' => {
+                'range' => {
+                  '@timestamp' => {
+                    'gt' => es_date_filter
+                  }
+                }
+              }
+            }
+          }
+        }
+      end
+    end
+    unless config[:types].nil?
+      options[:type] = config[:types]
+    end
+    options
+  end
+
+  def es_date_math_string
+    if config[:minutes_previous] == 0 && \
+       config[:hours_previous] == 0 && \
+       config[:weeks_previous] == 0 && \
+       config[:months_previous] == 0
+      return nil
+    else
+      es_math = "#{Time.now.utc.strftime '%Y-%m-%dT%H:%M:%S'}||"
+      if config[:minutes_previous] != 0
+        es_math += "-#{config[:minutes_previous]}m"
+      end
+      if config[:hours_previous] != 0
+        es_math += "-#{config[:hours_previous]}h"
+      end
+      if config[:days_previous] != 0
+        es_math += "-#{config[:days_previous]}d"
+      end
+      if config[:weeks_previous] != 0
+        es_math += "-#{config[:weeks_previous]}w"
+      end
+      if config[:months_previous] != 0
+        es_math += "-#{config[:months_previous]}M"
+      end
+      return es_math
+    end
+  end
+end

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
@@ -80,9 +80,7 @@ module ElasticsearchQuery
               },
               'filter' => {
                 'range' => {
-                  '@timestamp' => {
-                    'gt' => es_date_filter
-                  }
+                  '@timestamp' => { 'gt' => es_date_filter }
                 }
               }
             }

--- a/sensu-plugins-elasticsearch.gemspec
+++ b/sensu-plugins-elasticsearch.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '1.1.0'
   s.add_runtime_dependency 'rest-client',  '1.8.0'
+  s.add_runtime_dependency 'elasticsearch', '~> 1.0.12'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '0.30'


### PR DESCRIPTION
This adds elasticsearch query functionality, at least for a few basic cases but could be extended easily to as needed in a few other ways. I'm currently using it like this in sensu: 

check-es-query-count.rb -h elasticsearch.service.consul -q '*' --invert --types some_type -d 'log-index-%Y.%m.%d' --minutes-previous 30 -p 9200 -c 1 -w 100

I could also move the other checks and metrics over to the gem.