### PR TITLE
Support wait_for_status _cluster/health parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased][unreleased]
+- cluster-status check: added a new `status_timeout` option that will use elasticsearch's [`wait_for_status` parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#request-params) and wait up to the given number of seconds for the cluster to be green. This pervents false alerting during normal elasticsearch operations.
 
 ## [0.1.2] - 2015-08-11
 ### Added

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -62,6 +62,12 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 30
 
+  option :status_timeout,
+         description: 'Sets the time to wait for the cluster status to be green',
+         short: '-T SECS',
+         long: '--status_timeout SECS',
+         proc: proc(&:to_i)
+
   option :user,
          description: 'Elasticsearch User',
          short: '-u USER',
@@ -105,7 +111,11 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
   end
 
   def acquire_status
-    health = get_es_resource('/_cluster/health')
+    if config[:status_timeout]
+      health = get_es_resource("/_cluster/health?wait_for_status=green&timeout=#{config[:status_timeout]}s")
+    else
+      health = get_es_resource('/_cluster/health')
+    end
     health['status'].downcase
   end
 


### PR DESCRIPTION
cluster-status check: added a new `status_timeout` option that will use elasticsearch's [`wait_for_status` parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#request-params) and wait up to the given number of seconds for the cluster to be green. This pervents false alerting during normal elasticsearch operations.