### PR TITLE
Update for ES 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased][unreleased]
 ### Changed
-- Update metrics-es-node-graphite.rb for Elasticsearch 2.0
+- Update metrics-es-node-graphite.rb and check-es-node-status.rb for Elasticsearch 2.0
 
 ## [0.2.0] - 2015-10-15
 ### Changed

--- a/bin/check-es-node-status.rb
+++ b/bin/check-es-node-status.rb
@@ -4,7 +4,7 @@
 #
 # DESCRIPTION:
 #   This plugin checks the ElasticSearch node status, using its API.
-#   Works with ES 0.9x and ES 1.x
+#   Works with ES 0.9x, ES 1.x, and ES 2.x
 #
 # OUTPUT:
 #   plain text
@@ -70,7 +70,7 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
       headers = { 'Authorization' => auth }
     end
     r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout], headers: headers)
-    JSON.parse(r.get)
+    r.get
   rescue Errno::ECONNREFUSED
     critical 'Connection refused'
   rescue RestClient::RequestTimeout
@@ -80,8 +80,8 @@ class ESNodeStatus < Sensu::Plugin::Check::CLI
   end
 
   def acquire_status
-    health = get_es_resource('/')
-    health['status'].to_i
+    status = get_es_resource('/').code
+    status
   end
 
   def run


### PR DESCRIPTION
ES 2.x no longer exposes node status in the / API so use the HTTP status code instead.