### PR TITLE
fix broken url for stats in bin/check-es-file-descriptors.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## [0.2.1]
+- update wrong stats url in check-es-file-descriptors
+
+
 ## [Unreleased][unreleased]
 ### Changed
 - Update metrics-es-node-graphite.rb and check-es-node-status.rb for Elasticsearch 2.0

--- a/bin/check-es-file-descriptors.rb
+++ b/bin/check-es-file-descriptors.rb
@@ -91,6 +91,11 @@ class ESFileDescriptors < Sensu::Plugin::Check::CLI
     warning 'Connection timed out'
   end
 
+  def acquire_es_version
+    info = get_es_resource('/')
+    info['version']['number']
+  end
+
   def acquire_open_fds
     stats = get_es_resource('/_nodes/_local/stats?process=true')
     begin
@@ -102,7 +107,11 @@ class ESFileDescriptors < Sensu::Plugin::Check::CLI
   end
 
   def acquire_max_fds
-    info = get_es_resource('/_nodes/_local?process=true')
+    if Gem::Version.new(acquire_es_version) >= Gem::Version.new('2.0.0')
+      info = get_es_resource('/_nodes/_local/stats?process=true')
+    else
+      info = get_es_resource('/_nodes/_local?process=true')
+    end
     begin
       keys = info['nodes'].keys
       info['nodes'][keys[0]]['process']['max_file_descriptors'].to_i

--- a/lib/sensu-plugins-elasticsearch/version.rb
+++ b/lib/sensu-plugins-elasticsearch/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsElasticsearch
   module Version
     MAJOR = 0
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
URL was missing stats in self.

check before fix:
```
$ ./bin/check-es-file-descriptors.rb -h 10.55.150.181 -w 80 -c 90
Check failed to run: Infinity, ["./bin/check-es-file-descriptors.rb:117:in `to_i'", "./bin/check-es-file-descriptors.rb:117:in `run'", "/home/babrams/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

fixed:
```
$ ./bin/check-es-file-descriptors.rb -h 10.55.150.181 -w 80 -c 90
ESFileDescriptors OK: fd usage at 0% (338/64000)
```
