### PR TITLE
bug fix and enhancement

### DIFF
--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -102,6 +102,13 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :search_field,
+         description: 'field to search',
+         short: '-f FIELD',
+         long: '--field FIELD',
+         required: false,
+         default: 'message'
+
   option :query,
          description: 'Elasticsearch query',
          short: '-q QUERY',
@@ -167,17 +174,17 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
     response = client.count(build_request_options)
     if config[:invert]
       if response['count'] < config[:crit]
-        critical 'Query count was below critical threshold'
+        critical "Query count (#{response['count']}) was below critical threshold"
       elsif response['count'] < config[:warn]
-        warning 'Query count was below warning threshold'
+        warning "Query count (#{response['count']}) was below warning threshold"
       else
         ok
       end
     else
       if response['count'] > config[:crit]
-        critical 'Query count was above critical threshold'
+        critical "Query count (#{response['count']}) was above critical threshold"
       elsif response['count'] > config[:warn]
-        warning 'Query count was above warning threshold'
+        warning "Query count (#{response['count']}) was above warning threshold"
       else
         ok
       end
@@ -185,9 +192,9 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
 rescue Elasticsearch::Transport::Transport::Errors::NotFound
   if config[:invert]
     if response['count'] < config[:crit]
-      critical 'Query count was below critical threshold'
+      critical "Query count (#{response['count']}) was below critical threshold"
     elsif response['count'] < config[:warn]
-      warning 'Query count was below warning threshold'
+      warning "Query count (#{response['count']}) was below warning threshold"
     else
       ok
     end

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -178,7 +178,7 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
       elsif response['count'] < config[:warn]
         warning "Query count (#{response['count']}) was below warning threshold"
       else
-        ok
+        ok "Query count (#{response['count']}) was ok"
       end
     else
       if response['count'] > config[:crit]
@@ -186,7 +186,7 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
       elsif response['count'] > config[:warn]
         warning "Query count (#{response['count']}) was above warning threshold"
       else
-        ok
+        ok "Query count (#{response['count']}) was ok"
       end
     end
 rescue Elasticsearch::Transport::Transport::Errors::NotFound
@@ -196,7 +196,7 @@ rescue Elasticsearch::Transport::Transport::Errors::NotFound
     elsif response['count'] < config[:warn]
       warning "Query count (#{response['count']}) was below warning threshold"
     else
-      ok
+      ok "Query count (#{response['count']}) was ok"
     end
   else
     ok 'No results found, count was below thresholds'

--- a/bin/check-es-query-count.rb
+++ b/bin/check-es-query-count.rb
@@ -103,7 +103,7 @@ class ESQueryCount < Sensu::Plugin::Check::CLI
          default: false
 
   option :search_field,
-         description: 'field to search',
+         description: 'The Elasticsearch document field to search for your query string.',
          short: '-f FIELD',
          long: '--field FIELD',
          required: false,

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
@@ -97,6 +97,7 @@ module ElasticsearchQuery
   def es_date_math_string
     if config[:minutes_previous] == 0 && \
        config[:hours_previous] == 0 && \
+       config[:days_previous] == 0 && \
        config[:weeks_previous] == 0 && \
        config[:months_previous] == 0
       return nil

--- a/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
@@ -74,7 +74,7 @@ module ElasticsearchQuery
             'filtered' => {
               'query' => {
                 'query_string' => {
-                  'default_field' => 'message',
+                  'default_field' => config[:search_field],
                   'query' => config[:query]
                 }
               },


### PR DESCRIPTION
Hi, I started working with check-es-query-count plugin this week and found a couple things that needed fixing:

1) --days-previous was not working
2) the query field default was hard coded to 'message'. Cloudtrail events don't contain this field, so I added this as an option, with a default to message so nothing would break for others.
3) when running this check, i added the query count result to the output. This is a personal preference, but I found it very useful. 


Example:

Running the check without specifying the query field:
```
check-es-query-count.rb -h elasticsearch.my.dns  -d 'logstash-%Y.%m.%d' --days-previous 10 -p 9200 -c 10 -w 2  --types "cloudtrail"  -s http  -q 'AuthorizeSecurityGroupIngress'
ESQueryCount OK: Query count (0) was ok
```
Running the check and specifying the query field:
```
check-es-query-count.rb -h elasticsearch.my.dns  -d 'logstash-%Y.%m.%d' --days-previous 10 -p 9200 -c 10 -w 2  --types "cloudtrail"  -s http  -q 'AuthorizeSecurityGroupIngress' -f eventName
ESQueryCount CRITICAL: Query count (17) was above critical threshold
```

Notice the query count is 0 if your data is not found in 'message'.