### PR TITLE
Move node assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-es-heap.rb: Assignment of node from the stats variable happened before stats was assigned.  Moved node assignment to be after stats assignment.
 
 ## [0.4.2] - 2016-01-27
 ### Added

--- a/bin/check-es-heap.rb
+++ b/bin/check-es-heap.rb
@@ -107,12 +107,12 @@ class ESHeap < Sensu::Plugin::Check::CLI
   end
 
   def acquire_heap_data(return_max = false)
-    node = stats['nodes'].keys.first
     stats = if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
               acquire_es_resource('/_nodes/_local/stats?jvm=true')
             else
               acquire_es_resource('/_cluster/nodes/_local/stats?jvm=true')
             end
+    node = stats['nodes'].keys.first
     begin
       if return_max
         return stats['nodes'][node]['jvm']['mem']['heap_used_in_bytes'], stats['nodes'][node]['jvm']['mem']['heap_max_in_bytes']


### PR DESCRIPTION
Fixing bug: node variable assignment happens too early in check-es-heap.rb.  Just moved it down a line after the stats variable is assigned.

Apologies if the CHANGELOG is improperly versioned -- not sure if I'm allowed to version this fix or put it in Unreleased.