### PR TITLE
replace filtered with bool and must

### DIFF
--- a/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
+++ b/lib/sensu-plugins-elasticsearch/elasticsearch-query.rb
@@ -83,21 +83,20 @@ module ElasticsearchQuery
       unless es_date_start.nil?
         options[:body] = {
           'query' => {
-            'filtered' => {
-              'query' => {
+            'bool' => {
+              'must' => [{
                 'query_string' => {
                   'default_field' => config[:search_field],
                   'query' => config[:query]
                 }
-              },
-              'filter' => {
+              }, {
                 'range' => {
                   config[:timestamp_field] => {
                     'gt' => es_date_start,
                     'lt' => end_time.strftime('%Y-%m-%dT%H:%M:%S')
                   }
                 }
-              }
+              }]
             }
           }
         }


### PR DESCRIPTION
Filtered query is deprecated in ES 2.0 and removed in ES 5. It's replaced by bool and must
https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-filtered-query.html

Fixes #57 for check-es-query related features