### PR TITLE
Fix check-es-shard-allocation-status.rb for Elasticsearch 5.x compati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Fixed check-es-shard-allocation-status.rb for Elasticsearch 5.x compatibility (@Evesy)
 
 ## [1.1.3] - 2017-01-04
 ### Fixed

--- a/bin/check-es-shard-allocation-status.rb
+++ b/bin/check-es-shard-allocation-status.rb
@@ -53,7 +53,7 @@ class ESShardAllocationStatus < Sensu::Plugin::Check::CLI
          default: '9200'
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("#{config[:scheme]}://#{config[:server]}:#{config[:port]}/#{resource}", timeout: 45)
+    r = RestClient::Resource.new("#{config[:scheme]}://#{config[:server]}:#{config[:port]}#{resource}", timeout: 45)
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
@@ -62,7 +62,7 @@ class ESShardAllocationStatus < Sensu::Plugin::Check::CLI
   end
 
   def master?
-    state = get_es_resource('/_cluster/state?filter_routing_table=true&filter_metadata=true&filter_indices=true&filter_blocks=true&filter_nodes=true')
+    state = get_es_resource('/_cluster/state/master_node')
     local = get_es_resource('/_nodes/_local')
     local['nodes'].keys.first == state['master_node']
   end


### PR DESCRIPTION
…bility

## Pull Request Checklist

**Is this in reference to an existing issue?**
This fixes issue #66 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

This fixes the check-es-shard-allocation-status.rb check on Elasticsearch 5.x versions.

#### Known Compatablity Issues

This change is backwards compatible with previous Elasticsearch versions.

