### PR TITLE
metrics-es-cluster.rb: Don't assume 'cluster' key exists in transient_settings if not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-es-cluster.rb: Check to see if cluster key exists in transient_settings before trying to use it. (@RAR)
 
 ## [1.1.3] - 2017-01-04
 ### Fixed

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -180,7 +180,11 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
     if transient_settings.empty?
       return nil
     else
-      return %w(none new_primaries primaries all).index(transient_settings['cluster']['routing']['allocation']['enable'])
+      if transient_settings.key?('cluster')
+        return %w(none new_primaries primaries all).index(transient_settings['cluster']['routing']['allocation']['enable'])
+      else
+        return nil
+      end
     end
   end
 

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -177,14 +177,10 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   def acquire_allocation_status
     cluster_config = get_es_resource('/_cluster/settings')
     transient_settings = cluster_config['transient']
-    if transient_settings.empty?
-      return nil
+    if transient_settings.key?('cluster')
+      return %w(none new_primaries primaries all).index(transient_settings['cluster']['routing']['allocation']['enable'])
     else
-      if transient_settings.key?('cluster')
-        return %w(none new_primaries primaries all).index(transient_settings['cluster']['routing']['allocation']['enable'])
-      else
-        return nil
-      end
+      return nil
     end
   end
 


### PR DESCRIPTION
#### Purpose

One of our developers turned up logging level on a 1.7 cluster using:

curl -X PUT -d '{"transient": {"logger._root": "DEBUG"}}' http://localhost:9200/_cluster/settings

Which created a key under transient - the script assumed that if transient wasn't nil it would contain transient_settings['cluster']['routing']['allocation']['enable'].  This PR adds a test to see if 'cluster' exists in the transient_settings hash, and if so just returns nil.

#### Known Compatablity Issues

None
