### PR TITLE
use config[:timestamp_field] for sorting in Kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- use timestamp_field from config for sorting in Kibana  
+
 ## [1.4.0] - 2017-07-04
 ### Added
 - added ruby 2.4 testing (@majormoses)

--- a/bin/check-es-query-ratio.rb
+++ b/bin/check-es-query-ratio.rb
@@ -240,7 +240,7 @@ class ESQueryRatio < Sensu::Plugin::Check::CLI
       "#{URI.escape(Time.at(start_time).utc.strftime kibana_date_format)}',mode:absolute,to:'" \
       "#{URI.escape(Time.at(end_time).utc.strftime kibana_date_format)}'))&_a=(columns:!(_source),index:" \
       "#{URI.escape(index)},interval:auto,query:(query_string:(analyze_wildcard:!t,query:'" \
-      "#{URI.escape(config[:query])}')),sort:!('@timestamp',desc))&dummy"
+      "#{URI.escape(config[:query])}')),sort:!('#{config[:timestamp_field]}',desc))&dummy"
     end
   end
 


### PR DESCRIPTION
## Pull Request Checklist
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

#### Purpose
Bug fix: if a timestamp_field is defined it should be used for sorting instead of default timestamp
this is a not braking change becaseu config param uses @timestamp as default value

#### Known Compatibility Issues
NA