### PR TITLE
Fix when divisor = 0

### DIFF
--- a/bin/check-es-query-ratio.rb
+++ b/bin/check-es-query-ratio.rb
@@ -253,7 +253,7 @@ class ESQueryRatio < Sensu::Plugin::Check::CLI
     dividend = client.count(build_request_options)
     config[:query] = divisor_query
     divisor = client.count(build_request_options)
-    if divisor == 0
+    if divisor['count'] == 0
       critical 'Divisor is 0, ratio check cannot be performed, raising an alert'
     else
       response = {}


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Nope

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fix a failing case when divisor value is 0. The `if` check  was wrong, as it wasn't comparing the value.

#### Known Compatibility Issues
