### PR TITLE
Yellow only status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-
-## [1.6.1] - 2017-08-24
 ### Added
 - bin/check-es-cluster-health.rb: added option to alert only during a yellow state or only during a red state
 - bin/check-es-cluster-status.rb: added option to alert only during a yellow state or only during a red state
 
+## [1.6.1] - 2017-08-24
 ### Fixed
 - bin/check-es-query-ratio.rb: added support to define float thresholds (@cgarciaarano)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 
 ## [1.6.1] - 2017-08-24
+### Added
+- bin/check-es-cluster-health.rb: added option to alert only during a yellow state or only during a red state
+- bin/check-es-cluster-status.rb: added option to alert only during a yellow state or only during a red state
+
 ### Fixed
 - bin/check-es-query-ratio.rb: added support to define float thresholds (@cgarciaarano)
 

--- a/bin/check-es-cluster-health.rb
+++ b/bin/check-es-cluster-health.rb
@@ -111,13 +111,13 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
     health = client.cluster.health options
     case health['status']
     when 'yellow'
-      if !options[:alert_status].include? 'red'
+      if !options[:alert_status].downcase.include? 'red'
         warning 'Cluster state is Yellow'
       else
         ok 'Not alerting on yellow'
       end
     when 'red'
-      if !options[:alert_status].include? 'yellow'
+      if !options[:alert_status].downcase.include? 'yellow'
         critical 'Cluster state is Red'
       else
         ok 'Not alerting on red'

--- a/bin/check-es-cluster-health.rb
+++ b/bin/check-es-cluster-health.rb
@@ -92,15 +92,10 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 30
 
-  option :yellow_only,
-         description: 'If you would only like to be alerted for a yellow (or green) state',
-         long: '--yellow_only',
-         boolean: true
-
-  option :red_only,
-         description: 'If you would only like to be alerted for a red (or green) state',
-         long: '--red_only',
-         boolean: true
+  option :alert_status,
+         description: 'Only alert when status matches given (red/yellow) option (or green)',
+         long: '--alert_status STATUS',
+         default: ''
 
   def run
     options = {}
@@ -116,13 +111,13 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
     health = client.cluster.health options
     case health['status']
     when 'yellow'
-      if !options[:red_only]
+      if !options[:alert_status].include? 'red'
         warning 'Cluster state is Yellow'
       else
         ok 'Not alerting on yellow'
       end
     when 'red'
-      if !options[:yellow_only]
+      if !options[:alert_status].include? 'yellow'
         critical 'Cluster state is Red'
       else
         ok 'Not alerting on red'

--- a/bin/check-es-cluster-health.rb
+++ b/bin/check-es-cluster-health.rb
@@ -92,6 +92,16 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 30
 
+  option :yellow_only,
+         description: 'If you would only like to be alerted for a yellow (or green) state'
+         long: '--yellow_only'
+         boolean: true
+
+  option :red_only,
+         description: 'If you would only like to be alerted for a red (or green) state'
+         long: '--red_only'
+         boolean: true
+
   def run
     options = {}
     unless config[:level].nil?
@@ -106,9 +116,9 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
     health = client.cluster.health options
     case health['status']
     when 'yellow'
-      warning 'Cluster state is Yellow'
+      options[:red_only] ? ok : warning 'Cluster state is Yellow'
     when 'red'
-      critical 'Cluster state is Red'
+      options[:yellow_only] ? ok : critical 'Cluster state is Red'
     when 'green'
       ok
     else

--- a/bin/check-es-cluster-health.rb
+++ b/bin/check-es-cluster-health.rb
@@ -93,13 +93,13 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
          default: 30
 
   option :yellow_only,
-         description: 'If you would only like to be alerted for a yellow (or green) state'
-         long: '--yellow_only'
+         description: 'If you would only like to be alerted for a yellow (or green) state',
+         long: '--yellow_only',
          boolean: true
 
   option :red_only,
-         description: 'If you would only like to be alerted for a red (or green) state'
-         long: '--red_only'
+         description: 'If you would only like to be alerted for a red (or green) state',
+         long: '--red_only',
          boolean: true
 
   def run
@@ -116,9 +116,17 @@ class ESClusterHealth < Sensu::Plugin::Check::CLI
     health = client.cluster.health options
     case health['status']
     when 'yellow'
-      options[:red_only] ? ok : warning 'Cluster state is Yellow'
+      if !options[:red_only]
+        warning 'Cluster state is Yellow'
+      else
+        ok 'Not alerting on yellow'
+      end
     when 'red'
-      options[:yellow_only] ? ok : critical 'Cluster state is Red'
+      if !options[:yellow_only]
+        critical 'Cluster state is Red'
+      else
+        ok 'Not alerting on red'
+      end
     when 'green'
       ok
     else

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -144,13 +144,13 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
       when 'green'
         ok 'Cluster is green'
       when 'yellow'
-        if !options[:alert_status].include? 'red'
+        if !options[:alert_status].downcase.include? 'red'
           warning 'Cluster state is Yellow'
         else
           ok 'Not alerting on yellow'
         end
       when 'red'
-        if !options[:alert_status].include? 'yellow'
+        if !options[:alert_status].downcase.include? 'yellow'
           critical 'Cluster state is Red'
         else
           ok 'Not alerting on red'

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -83,6 +83,16 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          short: '-e',
          long: '--https'
 
+  option :yellow_only,
+         description: 'If you would only like to be alerted for a yellow (or green) state'
+         long: '--yellow_only'
+         boolean: true
+
+  option :red_only,
+         description: 'If you would only like to be alerted for a red (or green) state'
+         long: '--red_only'
+         boolean: true
+
   def get_es_resource(resource)
     headers = {}
     if config[:user] && config[:password]
@@ -139,9 +149,9 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
       when 'green'
         ok 'Cluster is green'
       when 'yellow'
-        warning 'Cluster is yellow'
+        options[:red_only] ? ok : warning 'Cluster state is Yellow'
       when 'red'
-        critical 'Cluster is red'
+        options[:yellow_only] ? ok : critical 'Cluster state is Red'
       end
     else
       ok 'Not the master'

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -83,15 +83,10 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          short: '-e',
          long: '--https'
 
-  option :yellow_only,
-         description: 'If you would only like to be alerted for a yellow (or green) state',
-         long: '--yellow_only',
-         boolean: true
-
-  option :red_only,
-         description: 'If you would only like to be alerted for a red (or green) state',
-         long: '--red_only',
-         boolean: true
+  option :alert_status,
+         description: 'Only alert when status matches given (red/yellow) option (or green)',
+         long: '--alert_status STATUS',
+         default: ''
 
   def get_es_resource(resource)
     headers = {}
@@ -149,13 +144,13 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
       when 'green'
         ok 'Cluster is green'
       when 'yellow'
-        if !options[:red_only]
+        if !options[:alert_status].include? 'red'
           warning 'Cluster state is Yellow'
         else
           ok 'Not alerting on yellow'
         end
       when 'red'
-        if !options[:yellow_only]
+        if !options[:alert_status].include? 'yellow'
           critical 'Cluster state is Red'
         else
           ok 'Not alerting on red'

--- a/bin/check-es-cluster-status.rb
+++ b/bin/check-es-cluster-status.rb
@@ -84,13 +84,13 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          long: '--https'
 
   option :yellow_only,
-         description: 'If you would only like to be alerted for a yellow (or green) state'
-         long: '--yellow_only'
+         description: 'If you would only like to be alerted for a yellow (or green) state',
+         long: '--yellow_only',
          boolean: true
 
   option :red_only,
-         description: 'If you would only like to be alerted for a red (or green) state'
-         long: '--red_only'
+         description: 'If you would only like to be alerted for a red (or green) state',
+         long: '--red_only',
          boolean: true
 
   def get_es_resource(resource)
@@ -149,9 +149,17 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
       when 'green'
         ok 'Cluster is green'
       when 'yellow'
-        options[:red_only] ? ok : warning 'Cluster state is Yellow'
+        if !options[:red_only]
+          warning 'Cluster state is Yellow'
+        else
+          ok 'Not alerting on yellow'
+        end
       when 'red'
-        options[:yellow_only] ? ok : critical 'Cluster state is Red'
+        if !options[:yellow_only]
+          critical 'Cluster state is Red'
+        else
+          ok 'Not alerting on red'
+        end
       end
     else
       ok 'Not the master'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No. I would've raised an issue, but instead raised a PR. The scenario for this PR is what if I want the cluster alerting Yellow to only report to a chat tool while alerting Red I want it to report to my pager solution. Currently, there's no way to split out the return result for different handlers. This will allow me to create two separate checks (unfortunate double-api hit) and route their results in different ways.

Please be kind if I missed anything.
I attempted `bundle exec rubocop` with no tests found (I didn't see any in test/ anyway, unlike the sensu pagerduty plugin)
Also, binstubs are never mentioned in the Contributions doc

Let me know if there are other steps I should take.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
