### PR TITLE
Don't try to fetch percolator metrics on ES 5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- metrics-es-cluster.rb: Don't try to fetch percolator stats on ES 5+, those stats have been removed (@eheydrick)
 
 ## [1.8.0] - 2017-11-21
 ### Added

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -70,7 +70,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: false
 
   option :enable_percolate,
-         description: 'Enables percolator stats',
+         description: 'Enables percolator stats (ES 2 and older only)',
          short: '-o',
          long: '--enable-percolate',
          default: false
@@ -166,7 +166,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
     cluster_metrics[cache_name]['evictions'] = cluster_stats['indices'][cache_name]['evictions']
     cluster_metrics['mem'] = cluster_stats['nodes']['jvm']['mem']
 
-    if config[:enable_percolate]
+    if config[:enable_percolate] && Gem::Version.new(acquire_es_version) < Gem::Version.new('5.0.0')
       cluster_metrics['percolate']['total'] = cluster_stats['indices']['percolate']['total']
       cluster_metrics['percolate']['time_in_millis'] = cluster_stats['indices']['percolate']['time_in_millis']
       cluster_metrics['percolate']['queries'] = cluster_stats['indices']['percolate']['queries']


### PR DESCRIPTION
Percolator metrics were removed in ES 5 and an exception is thrown trying to get them

## Pull Request Checklist

Fixes #97 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

The check would fail on ES 5+ due to Elasticsearch removing these stats in ES5.

Before w/ ES5 or ES6:

```
$ ruby metrics-es-cluster.rb -o
jed.local.elasticsearch.cluster.status 2 1518738947
jed.local.elasticsearch.cluster.number_of_nodes 1 1518738947
jed.local.elasticsearch.cluster.number_of_data_nodes 1 1518738947
jed.local.elasticsearch.cluster.active_primary_shards 0 1518738947
jed.local.elasticsearch.cluster.active_shards 0 1518738947
jed.local.elasticsearch.cluster.relocating_shards 0 1518738947
jed.local.elasticsearch.cluster.initializing_shards 0 1518738947
jed.local.elasticsearch.cluster.unassigned_shards 0 1518738947
jed.local.elasticsearch.cluster.delayed_unassigned_shards 0 1518738947
jed.local.elasticsearch.cluster.number_of_pending_tasks 0 1518738947
jed.local.elasticsearch.cluster.number_of_in_flight_fetch 0 1518738947
jed.local.elasticsearch.cluster.task_max_waiting_in_queue_millis 0 1518738947
jed.local.elasticsearch.cluster.active_shards_percent_as_number 100.0 1518738947
Check failed to run: undefined method `[]' for nil:NilClass, ["metrics-es-cluster.rb:170:in `acquire_cluster_metrics'", "metrics-es-cluster.rb:192:in `run'", "/Users/eric/.rvm/gems/ruby-2.3.0/gems/sensu-plugin-1.4.1/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```

After with ES5 or ES6:

```
$ ruby metrics-es-cluster.rb -o
jed.local.elasticsearch.cluster.status 2 1518739009
jed.local.elasticsearch.cluster.number_of_nodes 1 1518739009
jed.local.elasticsearch.cluster.number_of_data_nodes 1 1518739009
jed.local.elasticsearch.cluster.active_primary_shards 0 1518739009
jed.local.elasticsearch.cluster.active_shards 0 1518739009
jed.local.elasticsearch.cluster.relocating_shards 0 1518739009
jed.local.elasticsearch.cluster.initializing_shards 0 1518739009
jed.local.elasticsearch.cluster.unassigned_shards 0 1518739009
jed.local.elasticsearch.cluster.delayed_unassigned_shards 0 1518739009
jed.local.elasticsearch.cluster.number_of_pending_tasks 0 1518739009
jed.local.elasticsearch.cluster.number_of_in_flight_fetch 0 1518739009
jed.local.elasticsearch.cluster.task_max_waiting_in_queue_millis 0 1518739009
jed.local.elasticsearch.cluster.active_shards_percent_as_number 100.0 1518739009
jed.local.elasticsearch.cluster.fs.total_in_bytes 250790436864 1518739009
jed.local.elasticsearch.cluster.fs.free_in_bytes 61340811264 1518739009
jed.local.elasticsearch.cluster.fs.store_in_bytes 0 1518739009
jed.local.elasticsearch.cluster.fs.disk_reads 0 1518739009
jed.local.elasticsearch.cluster.fs.disk_writes 0 1518739009
jed.local.elasticsearch.cluster.fs.disk_read_size_in_bytes 0 1518739009
jed.local.elasticsearch.cluster.fs.disk_write_size_in_bytes 0 1518739009
jed.local.elasticsearch.cluster.fielddata.memory_size_in_bytes 0 1518739009
jed.local.elasticsearch.cluster.fielddata.evictions 0 1518739009
jed.local.elasticsearch.cluster.query_cache.memory_size_in_bytes 0 1518739009
jed.local.elasticsearch.cluster.query_cache.evictions 0 1518739009
jed.local.elasticsearch.cluster.mem.heap_used_in_bytes 500855080 1518739009
jed.local.elasticsearch.cluster.mem.heap_max_in_bytes 2077753344 1518739009
jed.local.elasticsearch.cluster.document_count 0 1518739009
```

I also verified that ES2 outputs percolator stats as expected.

#### Known Compatibility Issues

None. 