### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,11 @@ Style/GuardClause:
 Metrics/ModuleLength:
   Exclude:
     - 'lib/sensu-plugins-elasticsearch/elasticsearch-query.rb'
+
+# TODO: come cleanup the code that uses this once we figure out what we want to use
+Lint/UriEscapeUnescape:
+  Enabled: false
+
+# TODO: switch from `DateTime` to `Time` or `Date`
+Style/DateTime:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support @majormoses
+
+### Changes
+- added explicit dependency on `mixlib-shellout` to keep compatibility with ruby `2.1` (@majormoses)
+- appeased the cops and created TODOs (@majormoses)
+
 ## [1.12.0] - 2018-03-01
 ### Added
 - check-es-indices-field-number.rb: check if the number of fields in index(es) is approaching limit (default to 1000 in ES) (@huynt1979)

--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,9 @@ require 'English'
 require 'kitchen/rake_tasks'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -42,5 +42,5 @@ Kitchen::RakeTasks.new
 desc 'Alias for kitchen:all'
 task integration: 'kitchen:all'
 
-task default: %i(make_bin_executable yard rubocop check_binstubs integration)
-task quick: %i(make_bin_executable yard rubocop check_binstubs)
+task default: %i[make_bin_executable yard rubocop check_binstubs integration]
+task quick: %i[make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-es-heap.rb
+++ b/bin/check-es-heap.rb
@@ -142,7 +142,7 @@ class ESHeap < Sensu::Plugin::Check::CLI
 
   def acquire_heap_data(node)
     return node['jvm']['mem']['heap_used_in_bytes'], node['jvm']['mem']['heap_max_in_bytes']
-  rescue
+  rescue StandardError
     warning 'Failed to obtain heap used in bytes'
   end
 
@@ -166,7 +166,7 @@ class ESHeap < Sensu::Plugin::Check::CLI
     status = { crit: '', warn: '', ok: '' }
 
     # Check all the nodes in the cluster, alert if any of the nodes have heap usage above thresholds
-    stats['nodes'].each do |_, node|
+    stats['nodes'].each_value do |node|
       heap_used, heap_max = acquire_heap_data(node)
       heap_usage, output = acquire_heap_usage(heap_used, heap_max, node['name'])
       if heap_usage >= config[:crit]

--- a/bin/check-es-indices-sizes.rb
+++ b/bin/check-es-indices-sizes.rb
@@ -108,6 +108,8 @@ class ESCheckIndicesSizes < Sensu::Plugin::Check::CLI
 
   def get_indices_to_delete(starting_date, total_bytes_to_delete, indices_with_sizes)
     total_bytes_deleted = 0
+
+    # TODO: switch from `DateTime` to `Time` or `Date`
     curr_date = DateTime.now
 
     indices_to_delete = []
@@ -161,10 +163,10 @@ class ESCheckIndicesSizes < Sensu::Plugin::Check::CLI
     nodes_being_used = node_fs_stats['nodes'].values.select { |node| node['indices']['store']['size_in_bytes'] > 0 }
 
     # TODO: come back and cleanup all these rubocop disables with a little refactor
-    # rubocop:disable Style/SingleLineBlockParams,Metrics/LineLength
+    # rubocop:disable Metrics/LineLength
     used_in_bytes = nodes_being_used.map { |node| node['fs']['data'].map { |data| data['total_in_bytes'] - data['available_in_bytes'] }.flatten }.flatten.inject { |sum, x| sum + x }
     total_in_bytes = nodes_being_used.map { |node| node['fs']['data'].map { |data| data['total_in_bytes'] }.flatten }.flatten.inject { |sum, x| sum + x }
-    # rubocop:enable Style/SingleLineBlockParams,Metrics/LineLength
+    # rubocop:enable Metrics/LineLength
 
     if config[:maximum_megabytes] > 0
       target_bytes_used = config[:maximum_megabytes] * 1_000_000

--- a/bin/check-es-shard-allocation-status.rb
+++ b/bin/check-es-shard-allocation-status.rb
@@ -107,7 +107,7 @@ class ESShardAllocationStatus < Sensu::Plugin::Check::CLI
     # which is the ES default
     begin
       settings[type]['cluster']['routing']['allocation']['enable'].downcase
-    rescue
+    rescue StandardError
       'all'
     end
   end

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -144,8 +144,8 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def acquire_health
-    health = get_es_resource('/_cluster/health').reject { |k, _v| %w(cluster_name timed_out).include?(k) }
-    health['status'] = %w(red yellow green).index(health['status'])
+    health = get_es_resource('/_cluster/health').reject { |k, _v| %w[cluster_name timed_out].include?(k) }
+    health['status'] = %w[red yellow green].index(health['status'])
     health
   end
 
@@ -191,7 +191,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
     cluster_config = get_es_resource('/_cluster/settings')
     transient_settings = cluster_config['transient']
     if transient_settings.key?('cluster')
-      return %w(none new_primaries primaries all).index(transient_settings['cluster']['routing']['allocation']['enable'])
+      return %w[none new_primaries primaries all].index(transient_settings['cluster']['routing']['allocation']['enable'])
     else
       return nil
     end

--- a/bin/metrics-es-node-graphite.rb
+++ b/bin/metrics-es-node-graphite.rb
@@ -165,7 +165,7 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
     es_version = Gem::Version.new(acquire_es_version)
 
     if es_version >= Gem::Version.new('3.0.0')
-      stats_query_array = %w(indices http transport)
+      stats_query_array = %w[indices http transport]
       stats_query_array.push('jvm') if jvm_stats == true
       stats_query_array.push('os') if os_stat == true
       stats_query_array.push('process') if process_stats == true
@@ -173,7 +173,7 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
       stats_query_array.push('fs') if fs_stats == true
       stats_query_string = stats_query_array.join(',')
     elsif es_version >= Gem::Version.new('1.0.0')
-      stats_query_array = %w(indices http network transport thread_pool)
+      stats_query_array = %w[indices http network transport thread_pool]
       stats_query_array.push('jvm') if jvm_stats == true
       stats_query_array.push('os') if os_stat == true
       stats_query_array.push('process') if process_stats == true

--- a/sensu-plugins-elasticsearch.gemspec
+++ b/sensu-plugins-elasticsearch.gemspec
@@ -5,7 +5,7 @@ require 'date'
 require_relative 'lib/sensu-plugins-elasticsearch'
 
 # pvt_key = '~/.ssh/gem-private_key.pem'
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu Plugins and contributors']
   # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
                               service health and metrics for cluster, node, and more.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-elasticsearch'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for elasticsearch'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
@@ -42,11 +42,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'kitchen-docker',            '~> 2.6'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
+  # 0.17 requires ruby 2.3+
   s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support
- updated deps to keep ruby `2.1` and `2.2` support

Misc:
- appeased the cops and created TODOs to fix larger violations

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Address CVE, see parent issue for details
#### Known Compatibility Issues
removed ruby `> 2.1` support