### PR TITLE
Adding --cert-file option for all the checks which use RestClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- check-es-shard-allocation-status.rb, check-es-file-descriptors.rb, check-es-heap.rb: added `--cert-file` option which allows you to specify a ca-cert to be used to verify TLS (@vin01)
 
 ## [2.0.1] - 2018-03-27
 ### Security

--- a/bin/check-es-file-descriptors.rb
+++ b/bin/check-es-file-descriptors.rb
@@ -82,6 +82,10 @@ class ESFileDescriptors < Sensu::Plugin::Check::CLI
          short: '-e',
          long: '--https'
 
+  option :cert_file,
+         description: 'Cert file to use',
+         long: '--cert-file CERT'
+
   def get_es_resource(resource)
     headers = {}
     if config[:user] && config[:password]
@@ -95,7 +99,16 @@ class ESFileDescriptors < Sensu::Plugin::Check::CLI
                  'http'
                end
 
-    r = RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout], headers: headers)
+    r = if config[:cert_file]
+          RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}",
+                                   ssl_ca_file: config[:cert_file].to_s,
+                                   timeout: config[:timeout],
+                                   headers: headers)
+        else
+          RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}",
+                                   timeout: config[:timeout],
+                                   headers: headers)
+        end
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'

--- a/bin/check-es-heap.rb
+++ b/bin/check-es-heap.rb
@@ -90,6 +90,10 @@ class ESHeap < Sensu::Plugin::Check::CLI
          short: '-e',
          long: '--https'
 
+  option :cert_file,
+         description: 'Cert file to use',
+         long: '--cert-file CERT'
+
   option :all,
          description: 'Check all nodes in the ES cluster',
          short: '-a',
@@ -114,7 +118,16 @@ class ESHeap < Sensu::Plugin::Check::CLI
                  'http'
                end
 
-    r = RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout], headers: headers)
+    r = if config[:cert_file]
+          RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}",
+                                   ssl_ca_file: config[:cert_file].to_s,
+                                   timeout: config[:timeout],
+                                   headers: headers)
+        else
+          RestClient::Resource.new("#{protocol}://#{config[:host]}:#{config[:port]}#{resource}",
+                                   timeout: config[:timeout],
+                                   headers: headers)
+        end
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This option was added earlier in #101 but some checks were missed it seems. Since I was using these checks, I noticed it and added the option.