### PR TITLE
Strip invalid lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- metrics-es-node-graphite.rb: exclude non-numeric data from results (@boutetnico)
 
 ## [3.0.0] - 2018-12-17
 ### Breaking Changes

--- a/bin/metrics-es-node-graphite.rb
+++ b/bin/metrics-es-node-graphite.rb
@@ -314,7 +314,9 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
     end
 
     metrics.each do |k, v|
-      output([config[:scheme], k].join('.'), v, timestamp)
+      if v.is_a? Numeric
+        output([config[:scheme], k].join('.'), v, timestamp)
+      end
     end
     ok
   end


### PR DESCRIPTION
## Pull Request Checklist

Is this in reference to an existing issue? No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

This PR removes the following invalid lines from the output of the plugin:
```
elk01.elasticsearch.os.load_average
elk01.elasticsearch.indices.indexing.is_throttled false 1548954513
elk01.elasticsearch.indices.segments.file_sizes {} 1548954513
elk01.elasticsearch.fs.least_usage_estimate.path /data/elasticsearch/data/elk01-elk01/nodes/0 1548954513
elk01.elasticsearch.fs.most_usage_estimate.path /data/elasticsearch/data/elk01-elk01/nodes/0 1548954513
elk01.elasticsearch.fs.io_stats.devices {"device_name"=>"nvme1n1p1", "operations"=>157872407, "read_operations"=>691872, "write_operations"=>157180535, "read_kilobytes"=>50042456, "write_kilobytes"=>2478783444} 1548954513
elk01.elasticsearch.fs.io_stats.total {"operations"=>157872407, "read_operations"=>691872, "write_operations"=>157180535, "read_kilobytes"=>50042456, "write_kilobytes"=>2478783444} 1548954513
```

These lines are ignored by carbon and cause warning. This PR allows to remove these warnings.
```
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.indices.indexing.is_throttled false 1549036789]
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.indices.segments.file_sizes {} 1549036789]
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.fs.least_usage_estimate.path /data/elasticsearch/data/elk01-elk01/nodes/0 1549036789]
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.fs.most_usage_estimate.path /data/elasticsearch/data/elk01-elk01/nodes/0 1549036789]
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.fs.io_stats.devices {"device_name"=>"nvme1n1p1", "operations"=>160317981, "read_operations"=>705794, "write_operations"=>159612187, "read_kilobytes"=>51039824, "write_kilobytes"=>2539726412} 1549036789]
Feb  1 15:59:49 sensu01 carbon-cache.py[480]: 01/02/2019 15:59:49 :: [listener] invalid line received from client 127.0.0.1:42532, ignoring [elk01.elasticsearch.fs.io_stats.total {"operations"=>160317981, "read_operations"=>705794, "write_operations"=>159612187, "read_kilobytes"=>51039824, "write_kilobytes"=>2539726412} 1549036789]
```

#### Known Compatibility Issues

None