### PR TITLE
Fix for JSON.parse calls in metrics commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Fix for JSON.parse in metrics checks commands that inheret from Sensu::Plugin::Metric::CLI::JSON:Class
 
 ## [4.0.0] - 2019-05-07
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
 - Fix for JSON.parse in metrics checks commands that inheret from Sensu::Plugin::Metric::CLI::JSON:Class
 
 ## [4.0.0] - 2019-05-07

--- a/bin/metrics-es-cluster.rb
+++ b/bin/metrics-es-cluster.rb
@@ -122,7 +122,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
                                    timeout: config[:timeout],
                                    headers: headers)
         end
-    JSON.parse(r.get)
+    ::JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
   rescue RestClient::RequestTimeout

--- a/bin/metrics-es-node-graphite.rb
+++ b/bin/metrics-es-node-graphite.rb
@@ -142,7 +142,7 @@ class ESNodeGraphiteMetrics < Sensu::Plugin::Metric::CLI::Graphite
                                    timeout: config[:timeout],
                                    headers: headers)
         end
-    JSON.parse(r.get)
+    ::JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
   rescue RestClient::RequestTimeout

--- a/bin/metrics-es-node.rb
+++ b/bin/metrics-es-node.rb
@@ -103,7 +103,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
                                    timeout: config[:timeout],
                                    headers: headers)
         end
-    JSON.parse(r.get)
+    ::JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
   rescue RestClient::RequestTimeout


### PR DESCRIPTION
## Pull Request Checklist

Fix for #148 

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

#### Note
This only impacts ruby objects that inherent from the Sensu::Plugin::Metric::CLI class.
so generally only metrics commands.

check commands built using Sensu::Plugin::Check::CLI  are not impacted. 